### PR TITLE
Contact search handler case fix

### DIFF
--- a/lib/Textile/API/index.ts
+++ b/lib/Textile/API/index.ts
@@ -262,8 +262,10 @@ class API {
           case pb.QueryEvent.Type.DATA:
             const contact = pb.Contact.decode(queryEvent.data.value.value)
             handler({ type: 'result', contact, local: !!queryEvent.data.local })
+            break
           case pb.QueryEvent.Type.DONE:
             finish()
+            break
         }
       })
       streamError = NativeEvents.addListener('@textile/sdk/searchContactsError', (error: any) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textile/react-native-sdk",
-  "version": "1.1.0-rc23",
+  "version": "1.1.0-rc24",
   "description": "## Getting started",
   "nativePackage": true,
   "main": "dist/index.js",


### PR DESCRIPTION
We weren't using `break` and because of the weird and confusing way JS `switch` statements work, we were calling the search handler with a 'complete' event.

For a second, I thought maybe this would fix the "contact search not being completed when there is a result" bug, but this puts us firmly back in the situation where you can see that that bug exists.