### PR TITLE
Handle events with no data

### DIFF
--- a/ios/Events.m
+++ b/ios/Events.m
@@ -43,22 +43,19 @@ RCT_EXPORT_MODULE();
 {
   NSArray *eventDetails = [notification.userInfo valueForKey:@"detail"];
   NSString *eventName = [eventDetails objectAtIndex:0];
-  NSDictionary *eventData = [eventDetails objectAtIndex:1];
-
+  id eventData;
+  if (eventDetails.count > 1) {
+    eventData = [eventDetails objectAtIndex:1];
+  }
   [self sendEventWithName:eventName body:eventData];
 }
 
-+ (void)emitEventWithName:(NSString *)name andPayload:(NSString *)payload
++ (void)emitEventWithName:(NSString *)name andPayload:(NSString *)base64string
 {
-  NSData *data = [payload dataUsingEncoding:NSUTF8StringEncoding];
-  NSError *error;
-  NSDictionary *json = data ? [NSJSONSerialization JSONObjectWithData:data options:0 error:&error] : @{};
-  if (!error) {
-    NSDictionary *eventDetail = @{@"detail":@[name,json]};
-    [[NSNotificationCenter defaultCenter] postNotificationName:@"event-emitted"
-                                                        object:self
-                                                      userInfo:eventDetail];
-  }
+  NSDictionary *eventDetail = @{@"detail": base64string ? @[name, base64string] : @[name]};
+  [[NSNotificationCenter defaultCenter] postNotificationName:@"event-emitted"
+                                                      object:self
+                                                    userInfo:eventDetail];
 }
 
 @end

--- a/ios/Events.m
+++ b/ios/Events.m
@@ -51,11 +51,14 @@ RCT_EXPORT_MODULE();
 + (void)emitEventWithName:(NSString *)name andPayload:(NSString *)payload
 {
   NSData *data = [payload dataUsingEncoding:NSUTF8StringEncoding];
-  NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
-  NSDictionary *eventDetail = @{@"detail":@[name,json]};
-  [[NSNotificationCenter defaultCenter] postNotificationName:@"event-emitted"
-                                                      object:self
-                                                    userInfo:eventDetail];
+  NSError *error;
+  NSDictionary *json = data ? [NSJSONSerialization JSONObjectWithData:data options:0 error:&error] : @{};
+  if (!error) {
+    NSDictionary *eventDetail = @{@"detail":@[name,json]};
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"event-emitted"
+                                                        object:self
+                                                      userInfo:eventDetail];
+  }
 }
 
 @end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textile/react-native-sdk",
-  "version": "1.1.0-rc30",
+  "version": "1.1.0-rc31",
   "description": "## Getting started",
   "nativePackage": true,
   "main": "dist/index.js",


### PR DESCRIPTION
I guess we never sent events with no data before, now we do (`NODE_STARTED`, for example). Not dealing with that properly was causing a crash.

I _think_ this is fine for Android, will test more soon.