### PR TITLE
Depend on android-textile

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,7 +49,7 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
-    api project(':mobile')
+    implementation 'io.textile:textile:0.1.1'
 }
 
 task wrapper(type: Wrapper) {

--- a/android/mobile/build.gradle
+++ b/android/mobile/build.gradle
@@ -1,2 +1,0 @@
-configurations.maybeCreate("default")
-artifacts.add("default", file('../../node_modules/@textile/go-mobile/dist/android/mobile.aar'))

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,2 +1,1 @@
 rootProject.name = 'RNTextile'
-include ':mobile'

--- a/config/DOCS_TEMPLATE.md
+++ b/config/DOCS_TEMPLATE.md
@@ -11,36 +11,14 @@ Installation
 
 `react-native link @textile/react-native-sdk`
 
-**Update Search Paths in iOS**
-
-The library requires you to update two Search Paths in your iOS code to locate Textile's mobile framework (installed as a dependency of the React Native library).
-
-Open your project's XCode file. Then, in XCode, navigate to the `Root file -> Build Settings` in the search bar enter, `Search Paths`. You'll see a group of three entries, we are going to edit two.
-
-1.  In `Framework search paths` add `$(SRCROOT)/../node_modules/@textile/go-mobile/dist/ios`
-2.  In `Library search paths` add `$(SRCROOT)/../node_modules/@textile/go-mobile/dist/ios`
+Note: The iOS component of `@textile/react-native-sdk` should be installed using Cocoapods. `react-native-link` should do this correctly. More documentation coming here.
 
 **Update Android Gradle**
 
-Open your project and navigate to `android/settings.gradle`. At the end, you will add,
+You'll need to add Textile's maven repository to your project `build.gradle`'s `allProjects.repositories` section:
 
 ```
-include ':mobile'
-```
-
-Navigate to `app/build.gradle`. Add to the end of the `dependencies {` section,
-
-```
-api project(':mobile')
-```
-
-Finally, inside the `android` folder, you need to create a new folder called, `mobile`.
-
-Inside the newly created `mobile` folder, create a file called, `build.gradle` and for the contents of `build.gradle` enter,
-
-```
-configurations.maybeCreate("default")
-artifacts.add("default", file('../../node_modules/@textile/go-mobile/dist/android/mobile.aar'))
+maven { url "https://dl.bintray.com/textile/maven" }
 ```
 
 **Other dependencies**
@@ -53,7 +31,7 @@ The Textile library also requires that your project has two other libraries inst
 
 ### Typescript Types
 
-@textile/react-native-sdk is written in TypeScript and compiled to JavaScript. You can use either in your app. 
+@textile/react-native-sdk is written in TypeScript and compiled to JavaScript. You can use either in your app.
 
 #### Import Model Types
 

--- a/ios/RNTextile.xcodeproj/project.pbxproj
+++ b/ios/RNTextile.xcodeproj/project.pbxproj
@@ -209,18 +209,9 @@
 		58B511F01A9E6C8500147676 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SRCROOT)/../node_modules/@textile/go-mobile/dist/ios/**",
-					"$(SRCROOT)/../../go-mobile/dist/ios/**",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/../node_modules/@textile/go-mobile/dist/ios/**",
-					"$(SRCROOT)/../../go-mobile/dist/ios/**",
-				);
-				LIBRARY_SEARCH_PATHS = (
-					"$(SRCROOT)/../node_modules/@textile/go-mobile/dist/ios/**",
-					"$(SRCROOT)/../../go-mobile/dist/ios/**",
-				);
+				FRAMEWORK_SEARCH_PATHS = "";
+				HEADER_SEARCH_PATHS = "";
+				LIBRARY_SEARCH_PATHS = "";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = RNTextile;
 				SKIP_INSTALL = YES;
@@ -230,18 +221,9 @@
 		58B511F11A9E6C8500147676 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SRCROOT)/../node_modules/@textile/go-mobile/dist/ios/**",
-					"$(SRCROOT)/../../go-mobile/dist/ios/**",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/../node_modules/@textile/go-mobile/dist/ios/**",
-					"$(SRCROOT)/../../go-mobile/dist/ios/**",
-				);
-				LIBRARY_SEARCH_PATHS = (
-					"$(SRCROOT)/../node_modules/@textile/go-mobile/dist/ios/**",
-					"$(SRCROOT)/../../go-mobile/dist/ios/**",
-				);
+				FRAMEWORK_SEARCH_PATHS = "";
+				HEADER_SEARCH_PATHS = "";
+				LIBRARY_SEARCH_PATHS = "";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = RNTextile;
 				SKIP_INSTALL = YES;

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "typescript": "^3.1.1"
   },
   "dependencies": {
-    "@textile/go-mobile": "0.1.11",
+    "@textile/js-types": "0.1.11",
     "buffer": "^5.2.1"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textile/react-native-sdk",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "## Getting started",
   "nativePackage": true,
   "main": "dist/index.js",

--- a/src/Textile/Models/index.ts
+++ b/src/Textile/Models/index.ts
@@ -1,4 +1,4 @@
-import pb from '@textile/go-mobile'
+import pb from '@textile/js-types'
 
 export * from './SDK'
 export { pb }

--- a/yarn.lock
+++ b/yarn.lock
@@ -710,17 +710,15 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@textile/go-mobile@0.1.11":
+"@textile/js-types@0.1.11":
   version "0.1.11"
-  resolved "https://registry.yarnpkg.com/@textile/go-mobile/-/go-mobile-0.1.11.tgz#da3979c226f7b998d07e6b72a6835f6084d492ae"
-  integrity sha512-hTZ+KUfXQMjcM27P6MEYrm3Oc3fBlUPZwWJqWo1JbMRlvn4BS7sokv0MwCqcxC3CkW3/vqUBvrA/3itz6JKrgQ==
+  resolved "https://registry.yarnpkg.com/@textile/js-types/-/js-types-0.1.11.tgz#650247c092cec006634fa5bcb3d199d15e18050d"
   dependencies:
     protobufjs "^6.8.8"
 
 "@textile/tslint-rules@1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@textile/tslint-rules/-/tslint-rules-1.0.3.tgz#18d311d50557cfd7782f0aea539e2f4f8ed0fec3"
-  integrity sha512-OENriDthBfnstZWWhX1WvoRyFp0vBJRdpeU82rlKLtk2eW5n4Bc6iE3GQPH53PwavMaKSxrovxi/8yU5ClpTbw==
 
 "@types/cheerio@*":
   version "0.22.10"
@@ -1007,7 +1005,6 @@ argparse@^1.0.7:
 argparse@~0.1.15:
   version "0.1.16"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-0.1.16.tgz#cfd01e0fbba3d6caed049fbd758d40f65196f57c"
-  integrity sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=
   dependencies:
     underscore "~1.7.0"
     underscore.string "~2.4.0"
@@ -1064,14 +1061,12 @@ array-slice@^0.2.3:
 array-union@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
-  integrity sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=
   dependencies:
     array-uniq "^1.0.1"
 
 array-uniq@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
-  integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
 
 array-unique@^0.2.1:
   version "0.2.1"
@@ -1140,7 +1135,6 @@ atob@^2.1.1:
 autolinker@~0.15.0:
   version "0.15.3"
   resolved "https://registry.yarnpkg.com/autolinker/-/autolinker-0.15.3.tgz#342417d8f2f3461b14cf09088d5edf8791dc9832"
-  integrity sha1-NCQX2PLzRhsUzwkIjV7fh5HcmDI=
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -1397,7 +1391,6 @@ big-integer@^1.6.7:
 bindings@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.2.1.tgz#14ad6113812d2d37d72e67b4cacb4bb726505f11"
-  integrity sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=
 
 boolbase@~1.0.0:
   version "1.0.0"
@@ -1529,7 +1522,6 @@ capture-exit@^1.2.0:
 caseless@~0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.11.0.tgz#715b96ea9841593cc33067923f5ec60ebda4f7d7"
-  integrity sha1-cVuW6phBWTzDMGeSP17GDr2k99c=
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1622,7 +1614,6 @@ code-point-at@^1.0.0:
 coffee-script@^1.12.4:
   version "1.12.7"
   resolved "https://registry.yarnpkg.com/coffee-script/-/coffee-script-1.12.7.tgz#c05dae0cb79591d05b3070a8433a98c9a89ccc53"
-  integrity sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -1696,7 +1687,6 @@ concat-map@0.0.1:
 concat-stream@^1.4.6, concat-stream@^1.4.7, concat-stream@^1.5.2, concat-stream@^1.6.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
-  integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
   dependencies:
     buffer-from "^1.0.0"
     inherits "^2.0.3"
@@ -1814,7 +1804,6 @@ data-urls@^1.0.0:
 deasync@^0.1.9:
   version "0.1.14"
   resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.14.tgz#232ea2252b443948cad033d792eb3b24b0a3d828"
-  integrity sha512-wN8sIuEqIwyQh72AG7oY6YQODCxIp1eXzEZlZznBuwDF8Q03Tdy9QNp1BNZXeadXoklNrw+Ip1fch+KXo/+ASw==
   dependencies:
     bindings "~1.2.1"
     node-addon-api "^1.6.0"
@@ -1848,7 +1837,6 @@ decode-uri-component@^0.2.0:
 decompress-response@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
-  integrity sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=
   dependencies:
     mimic-response "^1.0.0"
 
@@ -1863,7 +1851,6 @@ deep-is@~0.1.3:
 deepmerge@^1.3.0, deepmerge@^1.3.1:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"
-  integrity sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ==
 
 default-require-extensions@^1.0.0:
   version "1.0.0"
@@ -1933,7 +1920,6 @@ detect-newline@^2.1.0:
 diacritics-map@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/diacritics-map/-/diacritics-map-0.1.0.tgz#6dfc0ff9d01000a2edf2865371cac316e94977af"
-  integrity sha1-bfwP+dAQAKLt8oZTccrDFulJd68=
 
 diff@^3.2.0:
   version "3.5.0"
@@ -1946,7 +1932,6 @@ discontinuous-range@1.0.0:
 docdash@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/docdash/-/docdash-1.0.3.tgz#1ca4d37940275f05f926c1326cde36d88b9f3fbc"
-  integrity sha512-gPepWBPJSWK70PRqOtxLvZ2FLJlw49DZASs73yqmM7uM45WEygQJmHPBrrQ9eLeEkgPKUzDv+sr2SHgQS1OQ0g==
 
 dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
@@ -2447,7 +2432,6 @@ form-data@~2.3.2:
 format-people@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/format-people/-/format-people-0.1.4.tgz#b1da1aad853e967426cceaf9f6a635a8eeaad97d"
-  integrity sha1-sdoarYU+lnQmzOr59qY1qO6q2X0=
   dependencies:
     extend-shallow "^2.0.1"
     markdown-utils "^0.7.3"
@@ -2466,7 +2450,6 @@ fresh@0.5.2:
 fs-exists-sync@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
-  integrity sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=
 
 fs-extra@^1.0.0:
   version "1.0.0"
@@ -2557,7 +2540,6 @@ getpass@^0.1.1:
 git-config-path@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/git-config-path/-/git-config-path-1.0.1.tgz#6d33f7ed63db0d0e118131503bab3aca47d54664"
-  integrity sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=
   dependencies:
     extend-shallow "^2.0.1"
     fs-exists-sync "^0.1.0"
@@ -2566,7 +2548,6 @@ git-config-path@^1.0.1:
 github-base@^0.5.1:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/github-base/-/github-base-0.5.4.tgz#90bcaa96175ad32202195c337e18fb69de349b41"
-  integrity sha1-kLyqlhda0yICGVwzfhj7ad40m0E=
   dependencies:
     define-property "^0.2.5"
     extend-shallow "^2.0.1"
@@ -2581,7 +2562,6 @@ github-base@^0.5.1:
 github-contributors@^0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/github-contributors/-/github-contributors-0.4.1.tgz#2dd11977fef313617418fdd122e4a160ddcd91cd"
-  integrity sha1-LdEZd/7zE2F0GP3RIuShYN3Nkc0=
   dependencies:
     format-people "^0.1.4"
     github-base "^0.5.1"
@@ -2589,7 +2569,6 @@ github-contributors@^0.4.0:
 github-url-from-git@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/github-url-from-git/-/github-url-from-git-1.5.0.tgz#f985fedcc0a9aa579dc88d7aff068d55cc6251a0"
-  integrity sha1-+YX+3MCpqledyI16/waNVcxiUaA=
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -2633,7 +2612,6 @@ globals@^9.18.0:
 globby@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
-  integrity sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=
   dependencies:
     array-union "^1.0.1"
     glob "^7.0.3"
@@ -2648,7 +2626,6 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6,
 gray-matter@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/gray-matter/-/gray-matter-2.1.1.tgz#3042d9adec2a1ded6a7707a9ed2380f8a17a430e"
-  integrity sha1-MELZrewqHe1qdwep7SOA+KF6Qw4=
   dependencies:
     ansi-red "^0.1.1"
     coffee-script "^1.12.4"
@@ -2764,7 +2741,6 @@ home-or-tmp@^3.0.0:
 homedir-polyfill@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz#743298cef4e5af3e194161fbadcc2151d3a058e8"
-  integrity sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==
   dependencies:
     parse-passwd "^1.0.0"
 
@@ -2792,7 +2768,6 @@ htmlparser2@^3.9.1:
 http-basic@^2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/http-basic/-/http-basic-2.5.1.tgz#8ce447bdb5b6c577f8a63e3fa78056ec4bb4dbfb"
-  integrity sha1-jORHvbW2xXf4pj4/p4BW7Eu02/s=
   dependencies:
     caseless "~0.11.0"
     concat-stream "^1.4.6"
@@ -2810,7 +2785,6 @@ http-errors@~1.6.2:
 http-response-object@^1.0.0, http-response-object@^1.0.1, http-response-object@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/http-response-object/-/http-response-object-1.1.0.tgz#a7c4e75aae82f3bb4904e4f43f615673b4d518c3"
-  integrity sha1-p8TnWq6C87tJBOT0P2FWc7TVGMM=
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -3039,7 +3013,6 @@ is-glob@^2.0.0, is-glob@^2.0.1:
 is-local-path@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-local-path/-/is-local-path-0.1.6.tgz#815d144b14d569cecbead4d5693097f00a9bf6c5"
-  integrity sha1-gV0USxTVac7L6tTVaTCX8Aqb9sU=
 
 is-number-object@^1.0.3:
   version "1.0.3"
@@ -3535,7 +3508,6 @@ js-yaml@^3.7.0, js-yaml@^3.9.0:
 js-yaml@^3.8.1:
   version "3.13.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.0.tgz#38ee7178ac0eea2c97ff6d96fff4b18c7d8cf98e"
-  integrity sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -3681,7 +3653,6 @@ kleur@^2.0.1:
 lazy-cache@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-2.0.2.tgz#b9190a4f913354694840859f8a8f7084d8822264"
-  integrity sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=
   dependencies:
     set-getter "^0.1.0"
 
@@ -3709,7 +3680,6 @@ levn@~0.3.0:
 list-item@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/list-item/-/list-item-1.1.1.tgz#0c65d00e287cb663ccb3cb3849a77e89ec268a56"
-  integrity sha1-DGXQDih8tmPMs8s4Sad+iewmilY=
   dependencies:
     expand-range "^1.8.1"
     extend-shallow "^2.0.1"
@@ -3785,14 +3755,12 @@ long@^4.0.0:
 longest-value@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/longest-value/-/longest-value-0.2.0.tgz#b77832b0ea5fa5a2c4a1bea9e08d7d15be697b5b"
-  integrity sha1-t3gysOpfpaLEob6p4I19Fb5pe1s=
   dependencies:
     longest "^1.0.0"
 
 longest@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
-  integrity sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
@@ -3836,12 +3804,10 @@ map-visit@^1.0.0:
 markdown-link@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/markdown-link/-/markdown-link-0.1.1.tgz#32c5c65199a6457316322d1e4229d13407c8c7cf"
-  integrity sha1-MsXGUZmmRXMWMi0eQinRNAfIx88=
 
 markdown-magic-github-contributors@^0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/markdown-magic-github-contributors/-/markdown-magic-github-contributors-0.0.3.tgz#46e7094d33b4418fe53dc6c6ea34b51ca9774688"
-  integrity sha1-RucJTTO0QY/lPcbG6jS1HKl3Rog=
   dependencies:
     deasync "^0.1.9"
     deepmerge "^1.3.1"
@@ -3852,7 +3818,6 @@ markdown-magic-github-contributors@^0.0.3:
 markdown-magic@^0.1.25:
   version "0.1.25"
   resolved "https://registry.yarnpkg.com/markdown-magic/-/markdown-magic-0.1.25.tgz#d044d90632b85ff1576a047da152852d53a8e55a"
-  integrity sha512-NBVMv2IPdKaRIXcL8qmLkfq9O17tkByTr8sRkJ4l76tkp401hxCUA0r9mkhtnGJRevCqZ2KoHrIf9WYQUn8ztA==
   dependencies:
     commander "^2.9.0"
     deepmerge "^1.3.0"
@@ -3866,7 +3831,6 @@ markdown-magic@^0.1.25:
 markdown-toc@^1.0.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/markdown-toc/-/markdown-toc-1.2.0.tgz#44a15606844490314afc0444483f9e7b1122c339"
-  integrity sha512-eOsq7EGd3asV0oBfmyqngeEIhrbkc7XVP63OwcJBIhH2EpG2PzFcbZdhy1jutXSlRBBVMNXHvMtSr5LAxSUvUg==
   dependencies:
     concat-stream "^1.5.2"
     diacritics-map "^0.1.0"
@@ -3884,7 +3848,6 @@ markdown-toc@^1.0.2:
 markdown-utils@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/markdown-utils/-/markdown-utils-0.7.3.tgz#4c583a31e251d69b313aceb3802a4f5d1b0f1e76"
-  integrity sha1-TFg6MeJR1psxOs6zgCpPXRsPHnY=
   dependencies:
     array-slice "^0.2.3"
     is-number "^2.1.0"
@@ -4199,7 +4162,6 @@ mimic-fn@^1.0.0:
 mimic-response@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
-  integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
 min-document@^2.19.0:
   version "2.19.0"
@@ -4326,7 +4288,6 @@ negotiator@0.6.1:
 node-addon-api@^1.6.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.6.2.tgz#d8aad9781a5cfc4132cc2fecdbdd982534265217"
-  integrity sha512-479Bjw9nTE5DdBSZZWprFryHGjUaQC31y1wHo19We/k0BZlrmhqQitWoUL0cD8+scljCbIUL+E58oRDEakdGGA==
 
 node-fetch@2.1.2:
   version "2.1.2"
@@ -4626,14 +4587,12 @@ p-try@^1.0.0:
 pad-right@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/pad-right/-/pad-right-0.2.2.tgz#6fbc924045d244f2a2a244503060d3bfc6009774"
-  integrity sha1-b7ySQEXSRPKiokRQMGDTv8YAl3Q=
   dependencies:
     repeat-string "^1.5.2"
 
 parse-git-config@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/parse-git-config/-/parse-git-config-1.1.1.tgz#d3a9984317132f57398712bba438e129590ddf8c"
-  integrity sha1-06mYQxcTL1c5hxK7pDjhKVkN34w=
   dependencies:
     extend-shallow "^2.0.1"
     fs-exists-sync "^0.1.0"
@@ -4665,7 +4624,6 @@ parse-json@^4.0.0:
 parse-link-header@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/parse-link-header/-/parse-link-header-0.4.1.tgz#f6bd615dc6713fd40935ce97945e4d3f522edf14"
-  integrity sha1-9r1hXcZxP9QJNc6XlF5NP1Iu3xQ=
   dependencies:
     xtend "~4.0.0"
 
@@ -4676,7 +4634,6 @@ parse-node-version@^1.0.0:
 parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
-  integrity sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
 
 parse5@4.0.0:
   version "4.0.0"
@@ -4908,7 +4865,6 @@ punycode@^2.1.0, punycode@^2.1.1:
 qs@^6.1.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
-  integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
 qs@~6.5.2:
   version "6.5.2"
@@ -5231,7 +5187,6 @@ regjsparser@^0.6.0:
 remarkable@^1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/remarkable/-/remarkable-1.7.1.tgz#aaca4972100b66a642a63a1021ca4bac1be3bff6"
-  integrity sha1-qspJchALZqZCpjoQIcpLrBvjv/Y=
   dependencies:
     argparse "~0.1.15"
     autolinker "~0.15.0"
@@ -5239,7 +5194,6 @@ remarkable@^1.7.1:
 remote-origin-url@^0.5.2:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/remote-origin-url/-/remote-origin-url-0.5.3.tgz#b9fc6ced2c826690d0b07218b2b8c17fcec88e87"
-  integrity sha512-crQ7Xk1m/F2IiwBx5oTqk/c0hjoumrEz+a36+ZoVupskQRE/q7pAwHKsTNeiZ31sbSTELvVlVv4h1W0Xo5szKg==
   dependencies:
     parse-git-config "^1.1.1"
 
@@ -5352,7 +5306,6 @@ ret@~0.1.10:
 right-pad-values@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/right-pad-values/-/right-pad-values-0.3.1.tgz#e7f47b50bc32e14dc49fd6acd73052253e7ef8a4"
-  integrity sha1-5/R7ULwy4U3En9as1zBSJT5++KQ=
   dependencies:
     isobject "^2.0.0"
     longest-value "^0.2.0"
@@ -5487,7 +5440,6 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
 set-getter@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/set-getter/-/set-getter-0.1.0.tgz#d769c182c9d5a51f409145f2fba82e5e86e80376"
-  integrity sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=
   dependencies:
     to-object-path "^0.3.0"
 
@@ -5555,12 +5507,10 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
 simple-concat@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.0.tgz#7344cbb8b6e26fb27d66b2fc86f9f6d5997521c6"
-  integrity sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=
 
 simple-get@^2.5.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-2.8.1.tgz#0e22e91d4575d87620620bc91308d57a77f44b5d"
-  integrity sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==
   dependencies:
     decompress-response "^3.3.0"
     once "^1.3.1"
@@ -5796,7 +5746,6 @@ strip-bom@^2.0.0:
 strip-color@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/strip-color/-/strip-color-0.1.0.tgz#106f65d3d3e6a2d9401cac0eb0ce8b8a702b4f7b"
-  integrity sha1-EG9l09PmotlAHKwOsM6LinArT3s=
 
 strip-eof@^1.0.0:
   version "1.0.0"
@@ -5833,7 +5782,6 @@ symbol-tree@^3.2.2:
 sync-request@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/sync-request/-/sync-request-3.0.1.tgz#caa1235aaf889ba501076a1834c436830a82fb73"
-  integrity sha1-yqEjWq+Im6UBB2oYNMQ2gwqC+3M=
   dependencies:
     concat-stream "^1.4.7"
     http-response-object "^1.0.1"
@@ -5871,7 +5819,6 @@ test-exclude@^4.2.1:
 then-request@^2.0.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/then-request/-/then-request-2.2.0.tgz#6678b32fa0ca218fe569981bbd8871b594060d81"
-  integrity sha1-ZnizL6DKIY/laZgbvYhxtZQGDYE=
   dependencies:
     caseless "~0.11.0"
     concat-stream "^1.4.7"
@@ -5920,7 +5867,6 @@ to-fast-properties@^2.0.0:
 to-gfm-code-block@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/to-gfm-code-block/-/to-gfm-code-block-0.1.1.tgz#25d045a5fae553189e9637b590900da732d8aa82"
-  integrity sha1-JdBFpfrlUxielje1kJANpzLYqoI=
 
 to-object-path@^0.3.0:
   version "0.3.0"
@@ -5947,7 +5893,6 @@ to-regex@^3.0.1, to-regex@^3.0.2:
 toml@^2.3.2:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/toml/-/toml-2.3.6.tgz#25b0866483a9722474895559088b436fd11f861b"
-  integrity sha512-gVweAectJU3ebq//Ferr2JUY4WKSDe5N+z0FvjDncLGyHmIDoxgY/2Ie4qfEIDm4IS7OA6Rmdm7pdEEdMcV/xQ==
 
 tough-cookie@>=2.3.3:
   version "3.0.0"
@@ -6107,12 +6052,10 @@ ultron@~1.1.0:
 underscore.string@~2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-2.4.0.tgz#8cdd8fbac4e2d2ea1e7e2e8097c42f442280f85b"
-  integrity sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=
 
 underscore@~1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
-  integrity sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
@@ -6390,7 +6333,6 @@ xpipe@^1.0.5:
 xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
-  integrity sha1-pcbVMr5lbiPbgg77lDofBJmNY68=
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
One more little step towards using the native sdks...

This one creates a dependency on `android-textile` which brings in `mobile` (`mobile.aar`) as a transitive dependency. The existing RN bride code uses it that way. No more project module called `mobile` in the sdk and host project to bring in the .aar.

I also published just the JS types in an NPM module called `@textile/js-types` and the SDK now depends on that instead of `@textile/go-mobile` (because we no longer need the .aar and .framework that `go-mobile` provided). No more post install fetch script!!! 