### PR TITLE
Correct android sdk dependency resolution

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,7 +49,7 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
-    implementation 'io.textile:textile:0.1.1'
+    api 'io.textile:textile:0.1.4'
 }
 
 task wrapper(type: Wrapper) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textile/react-native-sdk",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "## Getting started",
   "nativePackage": true,
   "main": "dist/index.js",


### PR DESCRIPTION
The dependency on `textile` (`android-textile`) needs to be listed as `api` so it's public interfaces are exposed to users of `react-native-sdk`.