### PR TITLE
Remove the tag=next so new version will be resolved as latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,8 +76,7 @@ jobs:
                 command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/react-native-sdk/.npmrc
             - run:
                 name: Publish package
-                command: npm publish --access=public --tag=next
-
+                command: npm publish --access=public
 workflows:
     version: 2
     react-native-sdk:


### PR DESCRIPTION
Since we're out of the rapid rc phase, we should remove this. Getting a support message about errors happening because an old version is being installed by `yarn add react-native-sdk`.