### PR TITLE
No Protobuf Any in public API

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,7 +49,7 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
-    api 'io.textile:textile:0.1.22'
+    api 'io.textile:textile:1.0.0'
 }
 
 task wrapper(type: Wrapper) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,7 +49,7 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
-    api 'io.textile:textile:1.0.0'
+    api 'io.textile:textile:1.0.1'
 }
 
 task wrapper(type: Wrapper) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,7 +49,7 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
-    api 'io.textile:textile:1.0.1'
+    api 'io.textile:textile:1.0.2'
 }
 
 task wrapper(type: Wrapper) {

--- a/android/src/main/java/io/textile/rnmobile/FeedBridge.java
+++ b/android/src/main/java/io/textile/rnmobile/FeedBridge.java
@@ -1,14 +1,19 @@
 package io.textile.rnmobile;
 
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
 
+import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
 import io.textile.pb.View;
+import io.textile.textile.FeedItemData;
 import io.textile.textile.Textile;
 
 public class FeedBridge extends ReactContextBaseJavaModule {
@@ -31,8 +36,16 @@ public class FeedBridge extends ReactContextBaseJavaModule {
             public void run() {
                 try {
                     View.FeedRequest request = View.FeedRequest.parseFrom(Util.decode(reqStr));
-                    View.FeedItemList list = Textile.instance().feed.list(request);
-                    promise.resolve(Util.encode(list.toByteArray()));
+                    List<FeedItemData> list = Textile.instance().feed.list(request);
+                    WritableArray converted = Arguments.createArray();
+                    for (FeedItemData feedItemData : list) {
+                        WritableMap map = Arguments.createMap();
+                        map.putString("block", feedItemData.block);
+                        map.putInt("type", feedItemData.type.ordinal());
+                        map.putString("data", Util.feedItemDataToBase64(feedItemData));
+                        converted.pushMap(map);
+                    }
+                    promise.resolve(converted);
                 }
                 catch (Exception e) {
                     promise.reject("list", e);

--- a/android/src/main/java/io/textile/rnmobile/TextileEvents.java
+++ b/android/src/main/java/io/textile/rnmobile/TextileEvents.java
@@ -1,11 +1,12 @@
 package io.textile.rnmobile;
 
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 import io.textile.pb.Model;
-import io.textile.pb.View;
+import io.textile.textile.FeedItemData;
 import io.textile.textile.TextileEventListener;
 
 class TextileEvents implements TextileEventListener {
@@ -57,8 +58,13 @@ class TextileEvents implements TextileEventListener {
     }
 
     @Override
-    public void threadUpdateReceived(View.FeedItem feedItem) {
-        emitter.emit("THREAD_UPDATE_RECEIVED", Util.encode(feedItem.toByteArray()));
+    public void threadUpdateReceived(String threadId, FeedItemData feedItemData) {
+        WritableMap map = Arguments.createMap();
+        map.putString("threadId", threadId);
+        map.putString("block", feedItemData.block);
+        map.putInt("type", feedItemData.type.ordinal());
+        map.putString("data", Util.feedItemDataToBase64(feedItemData));
+        emitter.emit("THREAD_UPDATE_RECEIVED", map);
     }
 
     @Override

--- a/android/src/main/java/io/textile/rnmobile/ThreadsBridge.java
+++ b/android/src/main/java/io/textile/rnmobile/ThreadsBridge.java
@@ -117,7 +117,7 @@ public class ThreadsBridge extends ReactContextBaseJavaModule {
             @Override
             public void run() {
                 try {
-                    Model.ContactList list = Textile.instance().threads.peers(threadId);
+                    Model.PeerList list = Textile.instance().threads.peers(threadId);
                     promise.resolve(Util.encode(list.toByteArray()));
                 }
                 catch (Exception e) {

--- a/android/src/main/java/io/textile/rnmobile/Util.java
+++ b/android/src/main/java/io/textile/rnmobile/Util.java
@@ -2,6 +2,8 @@ package io.textile.rnmobile;
 
 import android.util.Base64;
 
+import io.textile.textile.FeedItemData;
+
 public class Util {
 
     static String encode(byte[] data) {
@@ -16,5 +18,26 @@ public class Util {
             return null;
         }
         return Base64.decode(str, Base64.DEFAULT);
+    }
+
+    static String feedItemDataToBase64(FeedItemData feedItemData) {
+        switch(feedItemData.type) {
+            case TEXT:
+                return encode(feedItemData.text.toByteArray());
+            case LIKE:
+                return encode(feedItemData.like.toByteArray());
+            case COMMENT:
+                return encode(feedItemData.comment.toByteArray());
+            case FILES:
+                return encode(feedItemData.files.toByteArray());
+            case IGNORE:
+                return encode(feedItemData.ignore.toByteArray());
+            case JOIN:
+                return encode(feedItemData.join.toByteArray());
+            case LEAVE:
+                return encode(feedItemData.leave.toByteArray());
+            default:
+                return null;
+        }
     }
 }

--- a/ios/FeedBridge.m
+++ b/ios/FeedBridge.m
@@ -25,8 +25,12 @@ RCT_EXPORT_METHOD(list:(NSString*)reqStr resolver:(RCTPromiseResolveBlock)resolv
   NSError *error;
   NSData *requestData = [[NSData alloc] initWithBase64EncodedString:reqStr options:0];
   FeedRequest *request = [[FeedRequest alloc] initWithData:requestData error:&error];
-  FeedItemList *list = [Textile.instance.feed list:request error:&error];
-  fulfillWithResult([list.data base64EncodedStringWithOptions:0], error, resolve, reject);
+  NSArray<FeedItemData *> *list = [Textile.instance.feed list:request error:&error];
+  NSMutableArray *converted = [NSMutableArray arrayWithCapacity:list.count];
+  for (FeedItemData *feedItemData in list) {
+    [converted addObject:@{ @"block" : feedItemData.block, @"type" : [NSNumber numberWithUnsignedInteger:feedItemData.type], @"data" : feedItemDataToBase64(feedItemData) }];
+  }
+  fulfillWithResult(converted, error, resolve, reject);
 }
 
 @end

--- a/ios/TextileEvents.m
+++ b/ios/TextileEvents.m
@@ -9,6 +9,7 @@
 #endif
 
 #import "TextileEvents.h"
+#import "utils.h"
 
 @implementation TextileEvents
 
@@ -70,6 +71,15 @@ RCT_EXPORT_MODULE();
 
 - (void)threadUpdateReceived:(FeedItem *)feedItem {
   [self sendEventWithName:@"THREAD_UPDATE_RECEIVED" body:[feedItem.data base64EncodedStringWithOptions:0]];
+}
+
+- (void)threadUpdateReceived:(NSString *)threadId data:(FeedItemData *)feedItemData {
+  [self sendEventWithName:@"THREAD_UPDATE_RECEIVED" body:@{
+                                                           @"threadId" : threadId,
+                                                           @"block" : feedItemData.block,
+                                                           @"type" : [NSNumber numberWithUnsignedInteger:feedItemData.type],
+                                                           @"data" : feedItemDataToBase64(feedItemData)
+                                                           }];
 }
 
 - (void)threadAdded:(NSString *)threadId {

--- a/ios/ThreadsBridge.m
+++ b/ios/ThreadsBridge.m
@@ -63,7 +63,7 @@ RCT_EXPORT_METHOD(list:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejec
 
 RCT_EXPORT_METHOD(peers:(NSString*)threadId resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   NSError *error;
-  ContactList *list = [Textile.instance.threads peers:threadId error:&error];
+  PeerList *list = [Textile.instance.threads peers:threadId error:&error];
   fulfillWithResult([list.data base64EncodedStringWithOptions:0], error, resolve, reject);
 }
 

--- a/ios/utils.h
+++ b/ios/utils.h
@@ -6,4 +6,8 @@
 #import “React/RCTBridge.h”
 #endif
 
+#import <Textile/FeedItemData.h>
+
 void fulfillWithResult(id result, NSError *error, RCTPromiseResolveBlock resolve, RCTPromiseRejectBlock reject);
+
+NSString * feedItemDataToBase64(FeedItemData *feedItemData);

--- a/ios/utils.m
+++ b/ios/utils.m
@@ -1,4 +1,5 @@
 #import "utils.h"
+#import <Textile/TextileApi.h>
 
 void fulfillWithResult(id result, NSError *error, RCTPromiseResolveBlock resolve, RCTPromiseRejectBlock reject) {
   if (!error) {
@@ -6,4 +7,32 @@ void fulfillWithResult(id result, NSError *error, RCTPromiseResolveBlock resolve
   } else {
     reject(@(error.code).stringValue, error.localizedDescription, error);
   }
+}
+
+NSString * feedItemDataToBase64(FeedItemData *feedItemData) {
+  NSString *data;
+  switch (feedItemData.type) {
+    case FeedItemTypeText:
+      data = [feedItemData.text.data base64EncodedStringWithOptions:0];
+      break;
+    case FeedItemTypeComment:
+      data = [feedItemData.comment.data base64EncodedStringWithOptions:0];
+      break;
+    case FeedItemTypeLike:
+      data = [feedItemData.like.data base64EncodedStringWithOptions:0];
+      break;
+    case FeedItemTypeFiles:
+      data = [feedItemData.files.data base64EncodedStringWithOptions:0];
+      break;
+    case FeedItemTypeIgnore:
+      data = [feedItemData.ignore.data base64EncodedStringWithOptions:0];
+      break;
+    case FeedItemTypeJoin:
+      data = [feedItemData.join.data base64EncodedStringWithOptions:0];
+      break;
+    case FeedItemTypeLeave:
+      data = [feedItemData.leave.data base64EncodedStringWithOptions:0];
+      break;
+  }
+  return data;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textile/react-native-sdk",
-  "version": "1.2.13",
+  "version": "2.0.0",
   "description": "## Getting started",
   "nativePackage": true,
   "main": "dist/index.js",

--- a/src/events.ts
+++ b/src/events.ts
@@ -214,13 +214,16 @@ eventEmitter.addListener('NOTIFICATION_RECEIVED', (base64) => {
   }
 })
 
-eventEmitter.addListener('THREAD_UPDATE_RECEIVED', (dict: { threadId: string, block: string, type: FeedItemType, data: string }) => {
-  const { threadId, block, type, data } = dict
-  const feedItemData = toFeedItemData(type, block, data)
-  for (const listener of threadUpdateReceivedListeners) {
-    listener(threadId, feedItemData)
-  }
-})
+eventEmitter.addListener(
+  'THREAD_UPDATE_RECEIVED',
+  (dict: { threadId: string, block: string, type: FeedItemType, data: string }) => {
+    const { threadId, block, type, data } = dict
+    const feedItemData = toFeedItemData(type, block, data)
+    for (const listener of threadUpdateReceivedListeners) {
+      listener(threadId, feedItemData)
+    }
+  },
+)
 
 eventEmitter.addListener('THREAD_ADDED', (threadId) => {
   for (const listener of threadAddedListeners) {

--- a/src/events.ts
+++ b/src/events.ts
@@ -8,15 +8,16 @@ import { Buffer } from 'buffer'
 
 import {
   Notification,
-  FeedItem,
   Thread,
   Contact,
   INotification,
-  IFeedItem,
   IThread,
   IContact,
   EventSubscription,
+  FeedItemType,
+  FeedItemData,
 } from './model'
+import { toFeedItemData } from './util-internal'
 
 const { TextileEvents } = NativeModules
 const eventEmitter = Platform.select({
@@ -32,7 +33,7 @@ let nodeOnlineListeners: Array<() => void> = []
 let willStopNodeInBackgroundAfterDelayListeners: Array<(seconds: number) => void> = []
 let canceledPendingNodeStopListeners: Array<() => void> = []
 let notificationReceivedListeners: Array<(notification: INotification) => void> = []
-let threadUpdateReceivedListeners: Array<(feedItem: IFeedItem) => void> = []
+let threadUpdateReceivedListeners: Array<(threadId: string, feedItem: FeedItemData) => void> = []
 let threadAddedListeners: Array<(threadId: string) => void> = []
 let threadRemovedListeners: Array<(threadId: string) => void> = []
 let accountPeerAddedListeners: Array<(peerId: string) => void> = []
@@ -101,7 +102,7 @@ export function addNotificationReceivedListener(listener: (notification: INotifi
   )
 }
 
-export function addThreadUpdateReceivedListener(listener: (feedItem: IFeedItem) => void) {
+export function addThreadUpdateReceivedListener(listener: (threadId: string, feedItem: FeedItemData) => void) {
   threadUpdateReceivedListeners.push(listener)
   return new EventSubscription(
     () => threadUpdateReceivedListeners = threadUpdateReceivedListeners.filter((item) => item !== listener),
@@ -213,10 +214,11 @@ eventEmitter.addListener('NOTIFICATION_RECEIVED', (base64) => {
   }
 })
 
-eventEmitter.addListener('THREAD_UPDATE_RECEIVED', (base64) => {
-  const feedItem = FeedItem.decode(Buffer.from(base64, 'base64'))
+eventEmitter.addListener('THREAD_UPDATE_RECEIVED', (dict: { threadId: string, block: string, type: FeedItemType, data: string }) => {
+  const { threadId, block, type, data } = dict
+  const feedItemData = toFeedItemData(type, block, data)
   for (const listener of threadUpdateReceivedListeners) {
-    listener(feedItem)
+    listener(threadId, feedItemData)
   }
 })
 

--- a/src/feed.ts
+++ b/src/feed.ts
@@ -2,10 +2,11 @@ import { NativeModules } from 'react-native'
 import { Buffer } from 'buffer'
 import {
   FeedRequest,
-  FeedItemList,
   IFeedRequest,
-  IFeedItemList,
+  FeedItemType,
+  FeedItemData,
 } from './model'
+import { toFeedItemData } from './util-internal'
 
 const { FeedBridge } = NativeModules
 
@@ -15,8 +16,9 @@ const { FeedBridge } = NativeModules
  * Textile.feed.list();
  * ```
  */
-export async function list(request: IFeedRequest): Promise<IFeedItemList> {
+export async function list(request: IFeedRequest): Promise<FeedItemData[]> {
   const payload = FeedRequest.encode(request).finish()
-  const result = await FeedBridge.list(Buffer.from(payload).toString('base64'))
-  return FeedItemList.decode(Buffer.from(result, 'base64'))
+  const result: ReadonlyArray<{ type: FeedItemType, block: string, data: string }> = await FeedBridge.list(Buffer.from(payload).toString('base64'))
+  const feedItemData = result.map(({ type, block, data }) => toFeedItemData(type, block, data))
+  return feedItemData
 }

--- a/src/feed.ts
+++ b/src/feed.ts
@@ -18,7 +18,8 @@ const { FeedBridge } = NativeModules
  */
 export async function list(request: IFeedRequest): Promise<FeedItemData[]> {
   const payload = FeedRequest.encode(request).finish()
-  const result: ReadonlyArray<{ type: FeedItemType, block: string, data: string }> = await FeedBridge.list(Buffer.from(payload).toString('base64'))
+  const result: ReadonlyArray<{ type: FeedItemType, block: string, data: string }> =
+    await FeedBridge.list(Buffer.from(payload).toString('base64'))
   const feedItemData = result.map(({ type, block, data }) => toFeedItemData(type, block, data))
   return feedItemData
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -5,7 +5,7 @@ import {
   IFiles,
   IIgnore,
   IJoin,
-  ILeave
+  ILeave,
 } from '@textile/js-types'
 
 export * from '@textile/js-types'
@@ -24,7 +24,7 @@ export enum FeedItemType {
   Files,
   Ignore,
   Join,
-  Leave
+  Leave,
 }
 
 export interface TextFeedItem {
@@ -69,4 +69,11 @@ export interface LeaveFeedItem {
   value: ILeave
 }
 
-export type FeedItemData = TextFeedItem | CommentFeedItem | LikeFeedItem | FilesFeedItem | IgnoreFeedItem | JoinFeedItem | LeaveFeedItem
+export type FeedItemData =
+  TextFeedItem |
+  CommentFeedItem |
+  LikeFeedItem |
+  FilesFeedItem |
+  IgnoreFeedItem |
+  JoinFeedItem |
+  LeaveFeedItem

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,3 +1,13 @@
+import {
+  IText,
+  IComment,
+  ILike,
+  IFiles,
+  IIgnore,
+  IJoin,
+  ILeave
+} from '@textile/js-types'
+
 export * from '@textile/js-types'
 
 export class EventSubscription {
@@ -6,3 +16,57 @@ export class EventSubscription {
     this.cancel = cancel
   }
 }
+
+export enum FeedItemType {
+  Text,
+  Comment,
+  Like,
+  Files,
+  Ignore,
+  Join,
+  Leave
+}
+
+export interface TextFeedItem {
+  type: FeedItemType.Text
+  block: string
+  value: IText
+}
+
+export interface CommentFeedItem {
+  type: FeedItemType.Comment
+  block: string
+  value: IComment
+}
+
+export interface LikeFeedItem {
+  type: FeedItemType.Like
+  block: string
+  value: ILike
+}
+
+export interface FilesFeedItem {
+  type: FeedItemType.Files
+  block: string
+  value: IFiles
+}
+
+export interface IgnoreFeedItem {
+  type: FeedItemType.Ignore
+  block: string
+  value: IIgnore
+}
+
+export interface JoinFeedItem {
+  type: FeedItemType.Join
+  block: string
+  value: IJoin
+}
+
+export interface LeaveFeedItem {
+  type: FeedItemType.Leave
+  block: string
+  value: ILeave
+}
+
+export type FeedItemData = TextFeedItem | CommentFeedItem | LikeFeedItem | FilesFeedItem | IgnoreFeedItem | JoinFeedItem | LeaveFeedItem

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -5,13 +5,13 @@ import {
   AddThreadConfig,
   Thread,
   ThreadList,
-  ContactList,
+  PeerList,
   ThreadSnapshotQuery,
   QueryOptions,
   IAddThreadConfig,
   IThread,
   IThreadList,
-  IContactList,
+  IPeerList,
   IThreadSnapshotQuery,
   IQueryOptions,
 } from './model'
@@ -80,9 +80,9 @@ export async function list(): Promise<IThreadList> {
  * Textile.threads.peers(threadId);
  * ```
  */
-export async function peers(threadId: string): Promise<IContactList> {
+export async function peers(threadId: string): Promise<IPeerList> {
   const result = await ThreadsBridge.peers(threadId)
-  return ContactList.decode(Buffer.from(result, 'base64'))
+  return PeerList.decode(Buffer.from(result, 'base64'))
 }
 
 /**

--- a/src/util-internal.ts
+++ b/src/util-internal.ts
@@ -1,0 +1,59 @@
+import { Buffer } from 'buffer'
+import {
+  Text,
+  Comment,
+  Like,
+  Files,
+  Ignore,
+  Join,
+  Leave,
+  FeedItemType,
+  FeedItemData
+} from './model'
+
+export function toFeedItemData(type: FeedItemType, block: string, data: string): FeedItemData {
+  switch (type) {
+    case FeedItemType.Text:
+      return {
+        type,
+        block,
+        value: Text.decode(Buffer.from(data, 'base64'))
+      }
+    case FeedItemType.Comment:
+      return {
+        type,
+        block,
+        value: Comment.decode(Buffer.from(data, 'base64'))
+      }
+    case FeedItemType.Like:
+      return {
+        type,
+        block,
+        value: Like.decode(Buffer.from(data, 'base64'))
+      }
+    case FeedItemType.Files:
+      return {
+        type,
+        block,
+        value: Files.decode(Buffer.from(data, 'base64'))
+      }
+    case FeedItemType.Ignore:
+      return {
+        type,
+        block,
+        value: Ignore.decode(Buffer.from(data, 'base64'))
+      }
+    case FeedItemType.Join:
+      return {
+        type,
+        block,
+        value: Join.decode(Buffer.from(data, 'base64'))
+      }
+    case FeedItemType.Leave:
+      return {
+        type,
+        block,
+        value: Leave.decode(Buffer.from(data, 'base64'))
+      }
+  }
+}

--- a/src/util-internal.ts
+++ b/src/util-internal.ts
@@ -8,7 +8,7 @@ import {
   Join,
   Leave,
   FeedItemType,
-  FeedItemData
+  FeedItemData,
 } from './model'
 
 export function toFeedItemData(type: FeedItemType, block: string, data: string): FeedItemData {
@@ -17,43 +17,43 @@ export function toFeedItemData(type: FeedItemType, block: string, data: string):
       return {
         type,
         block,
-        value: Text.decode(Buffer.from(data, 'base64'))
+        value: Text.decode(Buffer.from(data, 'base64')),
       }
     case FeedItemType.Comment:
       return {
         type,
         block,
-        value: Comment.decode(Buffer.from(data, 'base64'))
+        value: Comment.decode(Buffer.from(data, 'base64')),
       }
     case FeedItemType.Like:
       return {
         type,
         block,
-        value: Like.decode(Buffer.from(data, 'base64'))
+        value: Like.decode(Buffer.from(data, 'base64')),
       }
     case FeedItemType.Files:
       return {
         type,
         block,
-        value: Files.decode(Buffer.from(data, 'base64'))
+        value: Files.decode(Buffer.from(data, 'base64')),
       }
     case FeedItemType.Ignore:
       return {
         type,
         block,
-        value: Ignore.decode(Buffer.from(data, 'base64'))
+        value: Ignore.decode(Buffer.from(data, 'base64')),
       }
     case FeedItemType.Join:
       return {
         type,
         block,
-        value: Join.decode(Buffer.from(data, 'base64'))
+        value: Join.decode(Buffer.from(data, 'base64')),
       }
     case FeedItemType.Leave:
       return {
         type,
         block,
-        value: Leave.decode(Buffer.from(data, 'base64'))
+        value: Leave.decode(Buffer.from(data, 'base64')),
       }
   }
 }

--- a/textile-react-native-sdk.podspec
+++ b/textile-react-native-sdk.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
 
   s.dependency 'React'
-  s.dependency 'Textile', '0.1.18'
+  s.dependency 'Textile', '1.0.0'
 
   s.preserve_paths      = 'README.md', 'LICENSE', 'package.json'
   s.source_files        = 'ios/**/*.{h,m}'

--- a/textile-react-native-sdk.podspec
+++ b/textile-react-native-sdk.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
 
   s.dependency 'React'
-  s.dependency 'Textile', '1.0.0'
+  s.dependency 'Textile', '1.0.1'
 
   s.preserve_paths      = 'README.md', 'LICENSE', 'package.json'
   s.source_files        = 'ios/**/*.{h,m}'

--- a/yarn.lock
+++ b/yarn.lock
@@ -710,10 +710,10 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@textile/js-types@0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@textile/js-types/-/js-types-0.2.4.tgz#73c28984b09368c219665c59e55331a977d29785"
-  integrity sha512-faDQGU+XzPZbiXEoDwYZR8E2jHC4cvCD7nResfpYfgD94KeCTIOISSuoRBG034gY/7uREbTh1uuNkmctUNkOsQ==
+"@textile/js-types@0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@textile/js-types/-/js-types-0.2.6.tgz#eb397cada3a03241b09d97434a3bb910d9277c4c"
+  integrity sha512-OzzPyyVgysyPhf761rRqf8saDGbgdWSktiQJLrXoeopMqpQUOqWUZbdqUJ3aIyia3Iq3b8ltnwve/ALrymD3DA==
   dependencies:
     protobufjs "^6.8.8"
 


### PR DESCRIPTION
Used the updated native sdks and simplifies APIs related to feed items. No more dealing with proto `Any` object decoding.

Fixes #118 