### PR TITLE
Encode session to base64

### DIFF
--- a/android/src/main/java/io/textile/rnmobile/CafesBridge.java
+++ b/android/src/main/java/io/textile/rnmobile/CafesBridge.java
@@ -73,7 +73,7 @@ public class CafesBridge extends ReactContextBaseJavaModule {
                 Textile.instance().cafes.refreshSession(peerId, new Handlers.CafeSessionHandler() {
                     @Override
                     public void onComplete(final Model.CafeSession session) {
-                        promise.resolve(session.toByteArray());
+                        promise.resolve(Util.encode(session.toByteArray()));
                     }
 
                     @Override

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textile/react-native-sdk",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "## Getting started",
   "nativePackage": true,
   "main": "dist/index.js",


### PR DESCRIPTION
Was causing an error on Android Photos when refreshing cafe session.