### PR TITLE
fix: error `This browser lacks typed array (Uint8Array) support`

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@textile/js-types": "0.6.11",
-    "buffer": "^5.2.1"
+    "buffer": "5.2.1"
   },
   "directories": {
     "src": "src"


### PR DESCRIPTION
caused by npm package `buffer` published in 2019-08