### PR TITLE
react-native-sdk: add swarm connect to ipfs api

### DIFF
--- a/android/manifest.gradle
+++ b/android/manifest.gradle
@@ -7,5 +7,5 @@ ext {
     mavenGradleVersion = '2.1'
 
     // Textile
-    textileVersion = '2.0.8'
+    textileVersion = '2.0.9'
 }

--- a/android/src/main/java/io/textile/rnmobile/IpfsBridge.java
+++ b/android/src/main/java/io/textile/rnmobile/IpfsBridge.java
@@ -40,6 +40,25 @@ public class IpfsBridge extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void connect(final String multiaddr, final Promise promise) {
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    if (Textile.instance().ipfs.swarmConnect(multiaddr)) {
+                        promise.resolve(true);
+                    } else {
+                        promise.reject(new Exception("connect"));
+                    }
+                }
+                catch (final Exception e) {
+                    promise.reject("connect", e);
+                }
+            }
+        });
+    }
+
+    @ReactMethod
     public void dataAtPath(final String path, final Promise promise) {
         executor.execute(new Runnable() {
             @Override

--- a/ios/IpfsBridge.m
+++ b/ios/IpfsBridge.m
@@ -26,6 +26,20 @@ RCT_EXPORT_METHOD(peerId:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRej
   fulfillWithResult([Textile.instance.ipfs peerId:&error], error, resolve, reject);
 }
 
+RCT_EXPORT_METHOD(connect:(NSString*)multiaddr resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+  NSError *error;
+  BOOL connected = [Textile.instance.ipfs swarmConnect:multiaddr error:&error];
+  if (!error) {
+    if (connected) {
+      resolve(true);
+    } else {
+      reject(@"EUNSPECIFIED", @"connect", nil);;
+    }
+  } else {
+    reject(@(error.code).stringValue, error.localizedDescription, error);
+  }
+}
+
 RCT_EXPORT_METHOD(dataAtPath:(NSString*)pth resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   [Textile.instance.ipfs dataAtPath:pth completion:^(NSData * _Nullable data, NSString * _Nullable mediaType, NSError * _Nonnull error) {
     NSDictionary *result = @{

--- a/src/ipfs.ts
+++ b/src/ipfs.ts
@@ -15,6 +15,19 @@ export async function peerId(): Promise<string> {
 }
 
 /**
+ * Open a new direct connection to a peer using an IPFS multiaddr
+ * ```typescript
+ * Textile.ipfs.connect(multiaddr);
+ * ```
+ */
+export async function connect(
+    multiaddr: string
+): Promise<boolean> {
+  const result = await IpfsBridge.connect(multiaddr)
+  return result
+}
+
+/**
  * Get raw file data by IPFS path. See `cat` method in IPFS.
  * ```typescript
  * Textile.ipfs.dataAtPath(path);

--- a/textile-react-native-sdk.podspec
+++ b/textile-react-native-sdk.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
 
   s.dependency 'React'
-  s.dependency 'Textile', '2.0.10'
+  s.dependency 'Textile', '2.0.11'
 
   s.preserve_paths      = 'README.md', 'LICENSE', 'package.json'
   s.source_files        = 'ios/**/*.{h,m}'


### PR DESCRIPTION
Add `swarm connect` to [Update React Native APIs to match more closely the JS and Rest API](https://github.com/textileio/react-native-sdk/issues/108)

Need PR:
[android-textile: add swarm connect to ipfs api](https://github.com/textileio/android-textile/pull/64)  and set android-textile to v2.0.9 
[ios-textile: add swarm connect to ipfs api](https://github.com/textileio/ios-textile/pull/84) and set ios-textile to v2.0.11