### PR TITLE
react-native-sdk: add raw ipfs pubsub pub and sub from android 2.0.10 and ios 2.0.12 and go-textile v0.7.6

### DIFF
--- a/android/manifest.gradle
+++ b/android/manifest.gradle
@@ -7,5 +7,5 @@ ext {
     mavenGradleVersion = '2.1'
 
     // Textile
-    textileVersion = '2.0.9'
+    textileVersion = '2.0.10'
 }

--- a/android/src/main/java/io/textile/rnmobile/IpfsBridge.java
+++ b/android/src/main/java/io/textile/rnmobile/IpfsBridge.java
@@ -77,4 +77,52 @@ public class IpfsBridge extends ReactContextBaseJavaModule {
             }
         });
     }
+
+    @ReactMethod
+    public void pubsubPub(final String topic, final String data, final Promise promise) {
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Textile.instance().ipfs.pubsubPub(topic, data);
+                    promise.resolve(true);
+                }
+                catch (final Exception e) {
+                    promise.reject("pubsubPub", e);
+                }
+            }
+        });
+    }
+
+    @ReactMethod
+    public void pubsubSub(final String topic, final Promise promise) {
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    String queryId = Textile.instance().ipfs.pubsubSub(topic);
+                    promise.resolve(queryId);
+                }
+                catch (final Exception e) {
+                    promise.reject("pubsubSub", e);
+                }
+            }
+        });
+    }
+
+    @ReactMethod
+    public void cancelPubsubSub(final String queryId, final Promise promise) {
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Textile.instance().ipfs.cancelPubsubSub(queryId);
+                    promise.resolve(null);
+                }
+                catch (final Exception e) {
+                    promise.reject("cancelPubsubSub", e);
+                }
+            }
+        });
+    }
 }

--- a/android/src/main/java/io/textile/rnmobile/TextileEvents.java
+++ b/android/src/main/java/io/textile/rnmobile/TextileEvents.java
@@ -101,6 +101,15 @@ class TextileEvents implements TextileEventListener {
     }
 
     @Override
+    public void pubsubQueryResult(final String queryId, final String message, final String messageId) {
+        final WritableMap map = new WritableNativeMap();
+        map.putString("queryId", queryId);
+        map.putString("message", message);
+        map.putString("messageId", messageId);
+        emitter.emit("PUBSUB_QUERY_RESULT", map);
+    }
+
+    @Override
     public void clientThreadQueryResult(final String queryId, final Model.Thread thread) {
         final WritableMap map = new WritableNativeMap();
         map.putString("queryId", queryId);

--- a/ios/IpfsBridge.m
+++ b/ios/IpfsBridge.m
@@ -50,6 +50,24 @@ RCT_EXPORT_METHOD(dataAtPath:(NSString*)pth resolver:(RCTPromiseResolveBlock)res
   }];
 }
 
+RCT_EXPORT_METHOD(pubsubPub:(NSString*)topic data:(NSString*)data resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+  NSError *error;
+  [Textile.instance.ipfs pubsubPub:topic data:data error:&error];
+  fulfillWithResult(true, error, resolve, reject);
+}
+
+RCT_EXPORT_METHOD(pubsubSub:(NSString*)topic resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+  NSError *error;
+  NSString *queryId = [Textile.instance.ipfs pubsubSub:topic error:&error];
+  fulfillWithResult(queryId, error, resolve, reject);
+}
+
+RCT_EXPORT_METHOD(cancelPubsubSub:(NSString*)queryId resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+  NSError *error;
+  [Textile.instance.ipfs cancelPubsubSub:queryId error:&error];
+  fulfillWithResult(nil, error, resolve, reject);
+}
+
 @end
 
 @implementation RCTBridge (IpfsBridge)

--- a/ios/TextileEvents.m
+++ b/ios/TextileEvents.m
@@ -109,6 +109,15 @@ RCT_EXPORT_MODULE();
   [self sendEventWithName:@"QUERY_ERROR" body:body];
 }
 
+- (void)pubsubQueryResult:(NSString *)queryId message:(NSString *)message  messageId:(NSString *)messageId {
+  NSDictionary *body = @{
+                         @"queryId": queryId,
+                         @"message": message,
+                         @"messageId": messageId
+                       };
+  [self sendEventWithName:@"PUBSUB_QUERY_RESULT" body:body];
+}
+
 - (void)clientThreadQueryResult:(NSString *)queryId thread:(Thread *)thread {
   NSDictionary *body = @{
                          @"queryId": queryId,

--- a/src/ipfs.ts
+++ b/src/ipfs.ts
@@ -20,9 +20,7 @@ export async function peerId(): Promise<string> {
  * Textile.ipfs.connect(multiaddr);
  * ```
  */
-export async function connect(
-    multiaddr: string
-): Promise<boolean> {
+export async function connect(multiaddr: string): Promise<boolean> {
   const result = await IpfsBridge.connect(multiaddr)
   return result
 }
@@ -38,4 +36,40 @@ export async function dataAtPath(
 ): Promise<{ data: Uint8Array; mediaType: string }> {
   const { data, mediaType } = await IpfsBridge.dataAtPath(path)
   return { data: Buffer.from(data, 'base64'), mediaType }
+}
+
+/**
+ * Publishes a message to a given pubsub topic
+ * ```typescript
+ * Textile.ipfs.pubsubPub(topic, data);
+ * ```
+ */
+export async function pubsubPub(
+  topic: string,
+  data: string | object
+): Promise<string> {
+  return await IpfsBridge.pubsubPub(
+    topic,
+    typeof data === 'string' ? data : JSON.stringify(data)
+  )
+}
+
+/**
+ * Subscribes to messages on a given topic
+ * ```typescript
+ * Textile.ipfs.pubsubSub(topic);
+ * ```
+ */
+export async function pubsubSub(
+  topic: string
+): Promise<{ queryId: string; queryHandle: { close: () => void } }> {
+  const queryId = await IpfsBridge.pubsubSub(topic)
+  return {
+    queryId,
+    queryHandle: {
+      close: () => {
+        IpfsBridge.cancelPubsubSub(queryId)
+      }
+    }
+  }
 }

--- a/textile-react-native-sdk.podspec
+++ b/textile-react-native-sdk.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
 
   s.dependency 'React'
-  s.dependency 'Textile', '2.0.11'
+  s.dependency 'Textile', '2.0.12'
 
   s.preserve_paths      = 'README.md', 'LICENSE', 'package.json'
   s.source_files        = 'ios/**/*.{h,m}'


### PR DESCRIPTION
 Add raw ipfs pubsub pub and sub to [Expose simple p2p direct message API](https://github.com/textileio/go-textile/issues/885)

For easy PR review, there is no latest docs in this PR

Need PR:
[android-textile: add raw ipfs pubsub pub and sub from go-textile v0.7.6](https://github.com/textileio/android-textile/pull/66) and set android-textile to 2.0.10 first
[ios-textile: add raw ipfs pubsub pub and sub from go-textile v0.7.6](https://github.com/textileio/ios-textile/pull/86) and set ios-textile to 2.0.12 first